### PR TITLE
Add a Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/greenbone/ospd-debsecan.svg?style=svg)](https://circleci.com/gh/greenbone/ospd-debsecan)
+[![Codecov](https://img.shields.io/codecov/c/github/greenbone/ospd-debsecan.svg)](https://codecov.io/gh/greenbone/ospd-debsecan)
 
 About OSPD-DEBSECAN
 -------------------


### PR DESCRIPTION
This commit adds a badge showing the current code coverage of the unit
tests in the master branch based on the analysis provided by Codecov.