### PR TITLE
Load Codecov badge directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/greenbone/ospd-debsecan.svg?style=svg)](https://circleci.com/gh/greenbone/ospd-debsecan)
-[![Codecov](https://img.shields.io/codecov/c/github/greenbone/ospd-debsecan.svg)](https://codecov.io/gh/greenbone/ospd-debsecan)
+[![Codecov](https://codecov.io/gh/greenbone/ospd-debsecan/branch/master/graphs/badge.svg)](https://codecov.io/gh/greenbone/ospd-debsecan)
 
 About OSPD-DEBSECAN
 -------------------


### PR DESCRIPTION
This commit loads the Codecov badge directly from `codecov.io` instead
of `shields.io` as the badge delivery by the latter sometimes fails to
deliver.